### PR TITLE
Adding encoding interface for syntactic nodes

### DIFF
--- a/ir/base/cid.go
+++ b/ir/base/cid.go
@@ -25,3 +25,7 @@ func (c Cid) WritePretty(w io.Writer) error {
 func (c Cid) MergeWith(ctx ir.MergeContext, x ir.Node) (ir.Node, error) {
 	panic("XXX")
 }
+
+func (c Cid) Encoding() ir.Encoder {
+	return nil
+}

--- a/ir/base/peer.go
+++ b/ir/base/peer.go
@@ -23,3 +23,7 @@ func (p Peer) WritePretty(w io.Writer) error {
 func (p Peer) MergeWith(ctx ir.MergeContext, x ir.Node) (ir.Node, error) {
 	panic("XXX")
 }
+
+func (p Peer) Encoding() ir.Encoder {
+	return nil
+}

--- a/ir/base/record.go
+++ b/ir/base/record.go
@@ -74,3 +74,7 @@ func (RecordAssembler) Assemble(ctx ir.AssemblerContext, src ir.Dict) (ir.Node, 
 		User: w.(ir.Dict),
 	}, nil
 }
+
+func (r Record) Encoding() ir.Encoder {
+	return nil
+}

--- a/ir/blob.go
+++ b/ir/blob.go
@@ -24,6 +24,10 @@ func (b Blob) encodeJSON() (interface{}, error) {
 	}{Type: BlobType, Value: b.Bytes}, nil
 }
 
+func (b Blob) Encoding() Encoder {
+	return b
+}
+
 func IsEqualBlob(x, y Blob) bool {
 	return bytes.Compare(x.Bytes, y.Bytes) == 0
 }

--- a/ir/bool.go
+++ b/ir/bool.go
@@ -25,6 +25,10 @@ func (b Bool) encodeJSON() (interface{}, error) {
 	}{Type: BoolType, Value: b.Value}, nil
 }
 
+func (b Bool) Encoding() Encoder {
+	return b
+}
+
 func decodeBool(s map[string]interface{}) (Node, error) {
 	r, ok := s["value"].(bool)
 	if !ok {

--- a/ir/dict.go
+++ b/ir/dict.go
@@ -175,11 +175,11 @@ func (d Dict) encodeJSON() (interface{}, error) {
 	}{Type: DictType, Tag: d.Tag, Pairs: []interface{}{}}
 
 	for _, p := range d.Pairs {
-		k, err := p.Key.encodeJSON()
+		k, err := p.Key.Encoding().encodeJSON()
 		if err != nil {
 			return nil, err
 		}
-		v, err := p.Value.encodeJSON()
+		v, err := p.Value.Encoding().encodeJSON()
 		if err != nil {
 			return nil, err
 		}
@@ -229,6 +229,10 @@ func decodeDict(s map[string]interface{}) (Node, error) {
 			})
 	}
 	return r, nil
+}
+
+func (d Dict) Encoding() Encoder {
+	return d
 }
 
 func IsEqualDict(x, y Dict) bool {

--- a/ir/marshal.go
+++ b/ir/marshal.go
@@ -5,6 +5,10 @@ import (
 	"fmt"
 )
 
+type Encoder interface {
+	encodeJSON() (interface{}, error)
+}
+
 type marshalType string
 
 // List of syntactic types supported
@@ -48,7 +52,7 @@ func decodeNode(v interface{}) (Node, error) {
 
 // Marshal syntactic representation
 func Marshal(n Node) ([]byte, error) {
-	c, err := n.encodeJSON()
+	c, err := n.Encoding().encodeJSON()
 	if err != nil {
 		return nil, err
 	}

--- a/ir/node.go
+++ b/ir/node.go
@@ -6,7 +6,8 @@ import (
 
 type Node interface {
 	WritePretty(w io.Writer) error
-	encodeJSON() (interface{}, error)
+	Encoding() Encoder // Exposes encoder only in syntactic nodes
+	//encodeJSON() (interface{}, error)
 }
 
 type Nodes []Node

--- a/ir/numbers.go
+++ b/ir/numbers.go
@@ -79,6 +79,13 @@ func (n Float) encodeJSON() (interface{}, error) {
 	}{Type: FloatType, Value: bn}, nil
 }
 
+func (n Int) Encoding() Encoder {
+	return n
+}
+
+func (n Float) Encoding() Encoder {
+	return n
+}
 func decodeInt(s map[string]interface{}) (Node, error) {
 	z := new(big.Int)
 	r, ok := s["value"].(string)

--- a/ir/set.go
+++ b/ir/set.go
@@ -15,6 +15,10 @@ func (s Set) Len() int {
 	return len(s.Elements)
 }
 
+func (s Set) Encoding() Encoder {
+	return s
+}
+
 func (s Set) WritePretty(w io.Writer) error {
 	if _, err := w.Write([]byte(s.Tag)); err != nil {
 		return err
@@ -54,7 +58,7 @@ func (s Set) encodeJSON() (interface{}, error) {
 	}{Type: SetType, Tag: s.Tag, Elements: []interface{}{}}
 
 	for _, n := range s.Elements {
-		no, err := n.encodeJSON()
+		no, err := n.Encoding().encodeJSON()
 		if err != nil {
 			return nil, err
 		}

--- a/ir/string.go
+++ b/ir/string.go
@@ -26,6 +26,10 @@ func (s String) encodeJSON() (interface{}, error) {
 	}{Type: StringType, Value: s.Value}, nil
 }
 
+func (s String) Encoding() Encoder {
+	return s
+}
+
 func decodeString(s map[string]interface{}) (Node, error) {
 	r, ok := s["value"].(string)
 	if !ok {


### PR DESCRIPTION
I was getting errors in the record Assembler because `Record` wasn't implementing `encodeJSON`. IIRC from our discussions only syntactic nodes should be "marshable", so in order for semantic nodes to implement correctly the `Node` interface, I've exposed `encodeJSON` to semantic nodes through an `Encoder` interface.

It should be straightforward, but let me know if there is anything missing. Thanks!