### PR TITLE
[Discuss] Smart nodes, metadata and TTL

### DIFF
--- a/ir/base/smart.go
+++ b/ir/base/smart.go
@@ -1,0 +1,93 @@
+package base
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/libp2p/go-smart-record/ir"
+)
+
+//NOTE: Including everything in the same file for discussion purposes.
+// This should be organized in its corresponding files when implementing it.
+type SmartNode interface {
+	ir.Node
+	Disassemble() ir.Node // returns only syntactic nodes
+}
+
+// SmartString is the smart node for the String type.
+// The difference is that additional metadata is included in the assembly process
+type SmartString struct {
+	Value    ir.String
+	Metadata metadataContext
+}
+
+// List of metadata attributes supported.
+type metadataContext struct {
+	ttl uint64
+}
+
+// TTL sets in metadata
+func TTL(value uint64) Metadata {
+	return func(m *metadataContext) error {
+		m.ttl = value
+		return nil
+	}
+}
+
+// Option type for smart records
+type Metadata func(*metadataContext) error
+
+// Applies metadata items to a metadataContext
+func (m *metadataContext) apply(items ...Metadata) error {
+	for i, item := range items {
+		if err := item(m); err != nil {
+			return fmt.Errorf("error applying metadata value: %s", i, err)
+		}
+	}
+	return nil
+}
+
+// The Assembler includes metadata to the syntactic node and assembles a smartNode.
+// SmartNode includes additional metadata
+// This belongs to (asm SequenceAssembler)
+func Assemble(ctx ir.AssemblerContext, src ir.Node, metadata ...Metadata) (SmartNode, error) {
+	s, ok := src.(ir.String)
+	if !ok {
+		return nil, fmt.Errorf("not a string")
+	}
+	var m metadataContext
+
+	if err := m.apply(metadata...); err != nil {
+		// Assembly fails if the wrong metadata is passed to the context.
+		return nil, err
+	}
+	return SmartString{s, m}, nil
+}
+
+func (s SmartString) WritePretty(w io.Writer) error {
+	_, err := fmt.Fprintf(w, "%q", s.Value)
+	return err
+}
+
+func (s SmartString) EncodeJSON() (interface{}, error) {
+	return s.Value.Disassemble().EncodeJSON()
+}
+
+// Disassemble returns the ir.String value without metadata
+func (s SmartString) Disassemble() ir.Node {
+	return s.Value
+}
+
+// UpdateWith updates metadataContext with new info.
+func (s SmartString) UpdateWith(ctx ir.UpdateContext, with ir.Node, metadata ...Metadata) (SmartNode, error) {
+	w, ok := with.(String)
+	if !ok {
+		return nil, fmt.Errorf("cannot update with a non-string")
+	}
+	// Update current metadata with updated values
+	if err := s.m.apply(metadata...); err != nil {
+		// Assembly fails if the wrong metadata is passed to the context.
+		return nil, err
+	}
+	return w, nil
+}


### PR DESCRIPTION
*Opening this PR for discussion before starting the implementation*

# Goal
Add metadata to semantic nodes. Metadata will be added in the assembly process and used in the VM for purposes such as the use of a TTL to garbage collect data in records that have expired.

# Proposal

### Metadata in smart nodes
*I included some sample code to aide my explanation*
- Add a `metadataContext` to smart nodes. This means adding a smart version for each syntactic type as shown in the code for `SmartString`.
- New metadata is added in the assembly process (see `Assemble` function).
- Disassembling a smart nodes removes the metadata and returns its syntactic representation.
- Updating a smart nodes updates its `metadataContext` with the new metadata (after running `apply` function).

I think this is a clean way to include any metadata in semantic nodes that will allow us not only to have granularity in the TTL and expiration of records, but also flexibility to add new metadata and implement additional logic over smart records.

Also, this structure accommodates the use of IPLD, as we could implement syntactic nodes in an IPLD schema and Assemble it to our semantic representation (it may be the case that smart nodes can also be represented as an IPLD schema, TBD). 


### TTL garbage collection
The VM will include a process that periodically checks if any data in records have expired. Every single node has its own metadata, so we may end up having different TTLs for different nodes in a `Pair` or a `Dict`. The rules to garbage collect data can be:
- "a node is expired if all of its descendants are expired and the node has exceeded its TTL"
- "a node can be reclaimed, if it is expired"

So:
- If a TTL of node has expired, remove that node. 
- If the node has child nodes (either because it is a `Dict` or a `Pair`) check if all the childs have expired.
- If any of the childs have expired, remove the child, but keep the parent Node until all of the childs have expired. 
- In `Pairs`, `Values` may have a different TTL than `Keys` if there was an update. In this case, the `Key` is the parent and the `Value` is the child, so as long as the `Value` still has enough TTL, the `Pair` stays.


Let me know your thoughts so we can start planning the implementation. Thanks!

//cc @barath, @petar 