### PR TITLE
Added configurable protocol prefix to server and client IDs

### DIFF
--- a/protocol/client.go
+++ b/protocol/client.go
@@ -45,7 +45,7 @@ func newSmartRecordClient(ctx context.Context, h host.Host, options ...ClientOpt
 	if err := cfg.apply(append([]ClientOption{clientDefaults}, options...)...); err != nil {
 		return nil, err
 	}
-	protocols := []protocol.ID{srProtocol}
+	protocols := []protocol.ID{cfg.protocolPrefix + srid}
 
 	// Start a smartRecordClient
 	e := &smartRecordClient{

--- a/protocol/options.go
+++ b/protocol/options.go
@@ -11,15 +11,17 @@ import (
 
 // Protocol ID
 const (
-	srProtocol protocol.ID = "/smart-record/0.0.1"
+	srid          protocol.ID = "/smart-record/0.0.1"
+	DefaultPrefix protocol.ID = "/ipfs"
 )
 
 // Options is a structure containing all the options that can be used when constructing the smart records env
 type serverConfig struct {
 	//datastore          ds.Batching
-	updateContext ir.UpdateContext
-	assembler     ir.AssemblerContext
-	gcPeriod      time.Duration
+	updateContext  ir.UpdateContext
+	assembler      ir.AssemblerContext
+	gcPeriod       time.Duration
+	protocolPrefix protocol.ID
 }
 
 // Option type for smart records
@@ -30,6 +32,7 @@ type ServerOption func(*serverConfig) error
 var serverDefaults = func(o *serverConfig) error {
 	o.updateContext = ir.DefaultUpdateContext{}
 	o.assembler = ir.AssemblerContext{Grammar: base.BaseGrammar}
+	o.protocolPrefix = DefaultPrefix
 
 	return nil
 }
@@ -42,6 +45,22 @@ func (c *serverConfig) apply(opts ...ServerOption) error {
 		}
 	}
 	return nil
+}
+
+// ClientProtocolPrefix configures the smart-record client protocol ID prefix.
+func ClientProtocolPrefix(p protocol.ID) ClientOption {
+	return func(c *clientConfig) error {
+		c.protocolPrefix = p
+		return nil
+	}
+}
+
+// ServerProtocolPrefix configures the smart-record client protocol ID prefix.
+func ServerProtocolPrefix(p protocol.ID) ServerOption {
+	return func(c *serverConfig) error {
+		c.protocolPrefix = p
+		return nil
+	}
 }
 
 // Assembler  configures the assembler to use in the smart record VM
@@ -68,9 +87,9 @@ func VMGcPeriod(gcP time.Duration) ServerOption {
 	}
 }
 
-//NOTE: No options available for clients at this moment. Leaving this here as a placeholder.
 // Options is a structure containing all the options that can be used when constructing the smart records env
 type clientConfig struct {
+	protocolPrefix protocol.ID
 }
 
 // Option type for smart records
@@ -87,5 +106,6 @@ func (c *clientConfig) apply(opts ...ClientOption) error {
 }
 
 var clientDefaults = func(o *clientConfig) error {
+	o.protocolPrefix = DefaultPrefix
 	return nil
 }

--- a/protocol/protocol_test.go
+++ b/protocol/protocol_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/libp2p/go-libp2p-core/host"
+	"github.com/libp2p/go-libp2p-core/protocol"
 	swarmt "github.com/libp2p/go-libp2p-swarm/testing"
 	bhost "github.com/libp2p/go-libp2p/p2p/host/basic"
 	xr "github.com/libp2p/go-routing-language/syntax"
@@ -16,6 +17,9 @@ var ttl = 2 * time.Second
 
 // Use small gcPeriod in server VM for tests
 var gcPeriod = 1 * time.Second
+
+// Use test prefix for protocol
+var prefix protocol.ID = "/test"
 
 var in1 = xr.Dict{
 	Pairs: xr.Pairs{
@@ -46,7 +50,7 @@ func setupServer(ctx context.Context, t *testing.T) *smartRecordServer {
 	s, err := newSmartRecordServer(
 		ctx,
 		bhost.New(swarmt.GenSwarm(t, ctx, swarmt.OptDisableReuseport)),
-		[]ServerOption{VMGcPeriod(gcPeriod)}...,
+		[]ServerOption{VMGcPeriod(gcPeriod), ServerProtocolPrefix(prefix)}...,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -59,6 +63,7 @@ func setupClient(ctx context.Context, t *testing.T) *smartRecordClient {
 	c, err := newSmartRecordClient(
 		ctx,
 		bhost.New(swarmt.GenSwarm(t, ctx, swarmt.OptDisableReuseport)),
+		[]ClientOption{ClientProtocolPrefix(prefix)}...,
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/protocol/server.go
+++ b/protocol/server.go
@@ -49,7 +49,7 @@ func newSmartRecordServer(ctx context.Context, h host.Host, options ...ServerOpt
 	if err := cfg.apply(append([]ServerOption{serverDefaults}, options...)...); err != nil {
 		return nil, err
 	}
-	protocols := []protocol.ID{srProtocol}
+	protocols := []protocol.ID{cfg.protocolPrefix + srid}
 
 	// Add host to assemblerContext
 	cfg.assembler.Host = h


### PR DESCRIPTION
Adds options to configure protocol prefix in client and server smart-record protocol ID.
Fixes #34 